### PR TITLE
Make cueue a generic container

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cueue"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Benedek Thaler"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cueue"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Benedek Thaler"]
 license = "MIT"

--- a/examples/basics.rs
+++ b/examples/basics.rs
@@ -7,30 +7,23 @@ fn main() {
     // These handles can be sent between threads, but cannot be duplicated.
     let (mut w, mut r) = cueue::cueue(1 << 20).unwrap();
 
-    // To write a cueue, first we need to make sure there's enough space for writing.
-    // w.begin_write() will make sure the maximum number of bytes available at that time
-    // for writing will be reserved.
-    // w.begin_write_if_needed(size) is a convenience wrapper, that calls begin_write
-    // only if there's less than size bytes available.
+    // To write a cueue, first we need to get a writable slice from it:
+    let buf = w.write_chunk();
 
     // Check if there are 9 bytes free for writing in the cueue.
-    if w.begin_write_if_needed(3 + 3 + 3) {
-        // If yes, write whatever we want - we are safe to unwrap()
-        println!("Write foo");
-        w.write(b"foo").unwrap();
-        println!("Write bar");
-        w.write(b"bar").unwrap();
-        println!("Write baz");
-        w.write(b"baz").unwrap();
+    if buf.len() >= 3 + 3 + 3 {
+        // If yes, write whatever we want
+        buf[..9].copy_from_slice(b"foobarbaz");
+
         // When done, make the written are available for reading.
         // Without this, the reader will not see the written but not committed changes.
-        w.end_write();
+        w.commit(9);
     }
 
     // Now read whatever is in the queue
-    let read_result = r.begin_read();
+    let read_result = r.read_chunk();
     assert_eq!(read_result, b"foobarbaz");
     println!("Read {}", String::from_utf8_lossy(read_result));
     // Mark the previously returned slice consumed, making it available for writing.
-    r.end_read();
+    r.commit();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,6 +351,18 @@ impl<'a, T> Writer<'a, T> {
     pub fn is_abandoned(&mut self) -> bool {
         std::sync::Arc::get_mut(&mut self.mem).is_some()
     }
+
+    /// Write and commit a single element, or return it if the queue was full.
+    pub fn push(&mut self, t: T) -> Result<(), T> {
+        let chunk = self.write_chunk();
+        if !chunk.is_empty() {
+            chunk[0] = t;
+            self.commit(1);
+            Ok(())
+        } else {
+            Err(t)
+        }
+    }
 }
 
 unsafe impl<'a, T> Send for Writer<'a, T> {}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,70 +17,91 @@ fn test_next_power_two() {
 
 #[test]
 fn test_capacity() {
-    let (w, r) = cueue(16).unwrap();
+    let (w, r) = cueue::<'_, u8>(16).unwrap();
     assert_eq!(w.capacity(), r.capacity());
     assert!(w.capacity() >= 4096);
 }
 
 #[test]
 fn test_writer() {
-    let (mut w, _) = cueue(16).unwrap();
+    let (mut w, r) = cueue::<'_, u8>(16).unwrap();
 
     let cap = w.capacity();
 
-    assert_eq!(w.write_capacity(), 0);
+    let buf = w.write_chunk();
+    assert_eq!(buf.len(), cap);
+    w.commit(0);
 
-    assert_eq!(w.begin_write(), cap);
-    assert_eq!(w.write_capacity(), cap);
-    w.end_write();
+    let buf = w.write_chunk();
+    assert_eq!(buf.len(), cap);
+    w.commit(3);
 
-    assert_eq!(w.write_capacity(), cap);
-    w.write(b"foo").unwrap();
-    assert_eq!(w.write_capacity(), cap - 3);
-}
+    let buf = w.write_chunk();
+    assert_eq!(buf.len(), cap - 3);
 
-#[test]
-fn test_writer_on_demand() {
-    let (mut w, _) = cueue(16).unwrap();
-    let cap = w.capacity();
-
-    assert_eq!(w.begin_write_if_needed(1), true);
-    assert_eq!(w.begin_write_if_needed(2), true);
-    assert_eq!(w.begin_write_if_needed(cap), true);
-    assert_eq!(w.begin_write_if_needed(cap + 1), false);
+    assert!(!w.is_abandoned());
+    std::mem::drop(r);
+    assert!(w.is_abandoned());
 }
 
 #[test]
 fn test_reader() {
     let (mut w, mut r) = cueue(16).unwrap();
 
-    let empty = r.begin_read();
+    let empty = r.read_chunk();
     assert_eq!(empty.len(), 0);
-    r.end_read();
+    r.commit();
 
-    w.begin_write();
-    w.write(b"foo").unwrap();
-    w.end_write();
+    let buf = w.write_chunk();
+    buf[..3].copy_from_slice(b"foo");
+    w.commit(3);
 
-    let foo = r.begin_read();
+    let foo = r.read_chunk();
     assert_eq!(foo, b"foo");
-    r.end_read();
+    r.commit();
+
+    assert!(!r.is_abandoned());
+    std::mem::drop(w);
+    assert!(r.is_abandoned());
 }
 
 #[test]
 fn test_full() {
+    let (mut w, mut r) = cueue::<'_, u8>(16).unwrap();
+
+    let buf = w.write_chunk();
+    let buflen = buf.len();
+    assert_eq!(buf.len(), w.capacity());
+    w.commit(buflen);
+
+    let empty = w.write_chunk();
+    assert_eq!(empty.len(), 0);
+
+    let full = r.read_chunk();
+    assert_eq!(full.len(), buflen);
+    assert_eq!(full.len(), r.capacity());
+}
+
+#[test]
+fn test_reuse() {
     let (mut w, mut r) = cueue(16).unwrap();
 
-    let cap = w.begin_write();
-    for _ in 0..cap {
-        w.write(b"x").unwrap();
+    // fill the queue with strings
+    let buf = w.write_chunk();
+    for s in buf.into_iter() {
+        *s = "foobar";
     }
-    assert!(w.write(b"x").is_err());
-    w.end_write();
-    assert_eq!(w.write_capacity(), 0);
+    let buflen = buf.len();
+    w.commit(buflen);
 
-    let full = r.begin_read();
-    assert_eq!(full.len(), cap);
+    // consume everything
+    let full = r.read_chunk();
+    assert_eq!(full.len(), buflen);
+    r.commit();
+
+    // try writing again
+    let buf = w.write_chunk();
+    assert_eq!(buf[0], "foobar");
 }
 
 #[test]
@@ -91,9 +112,14 @@ fn test_cueue_threaded_w_r() {
     let wt = std::thread::spawn(move || {
         let mut msg: u8 = 0;
         for _ in 0..maxi {
-            while w.begin_write_if_needed(1) == false {}
-            w.write(&[msg; 1]).unwrap();
-            w.end_write();
+            let buf = loop {
+                let buf = w.write_chunk();
+                if buf.len() > 0 {
+                    break buf;
+                }
+            };
+            buf[0] = msg;
+            w.commit(1);
 
             msg = msg.wrapping_add(1);
         }
@@ -103,13 +129,13 @@ fn test_cueue_threaded_w_r() {
         let mut emsg: u8 = 0;
         let mut i = 0;
         while i < maxi {
-            let rr = r.begin_read();
+            let rr = r.read_chunk();
             for msg in rr {
-                assert_eq!(msg, msg);
+                assert_eq!(*msg, emsg);
                 emsg = emsg.wrapping_add(1);
                 i += 1;
             }
-            r.end_read();
+            r.commit();
         }
     });
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -105,6 +105,30 @@ fn test_reuse() {
 }
 
 #[test]
+fn test_push() {
+    let (mut w, _) = cueue(16).unwrap();
+    let cap = w.capacity();
+
+    for i in 0..cap {
+        assert_eq!(w.push(i), Ok(()));
+    }
+
+    assert_eq!(w.push(0), Err(0));
+}
+
+#[test]
+fn test_push_string() {
+    let (mut w, _) = cueue(16).unwrap();
+    let cap = w.capacity();
+
+    for i in 0..cap {
+        assert_eq!(w.push(i.to_string()), Ok(()));
+    }
+
+    assert_eq!(w.push("foo".to_string()), Err("foo".to_string()));
+}
+
+#[test]
 fn test_cueue_threaded_w_r() {
     let (mut w, mut r) = cueue(16).unwrap();
     let maxi = 1_000_000;


### PR DESCRIPTION
- Release 0.1.1
- Make Cueue generic over the contained elements
- Use is_abandoned in bench
- Add Writer push method
