### PR TITLE
Change write_pos()/read_pos() from &mut to &

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,13 +362,13 @@ where
     }
 
     #[inline]
-    fn write_pos(&mut self) -> &mut std::sync::atomic::AtomicU64 {
-        unsafe { &mut (*self.cb).write_position.0 }
+    fn write_pos(&self) -> &std::sync::atomic::AtomicU64 {
+        unsafe { &(*self.cb).write_position.0 }
     }
 
     #[inline]
-    fn read_pos(&mut self) -> &mut std::sync::atomic::AtomicU64 {
-        unsafe { &mut (*self.cb).read_position.0 }
+    fn read_pos(&self) -> &std::sync::atomic::AtomicU64 {
+        unsafe { &(*self.cb).read_position.0 }
     }
 }
 
@@ -445,13 +445,13 @@ where
     }
 
     #[inline]
-    fn write_pos(&mut self) -> &mut std::sync::atomic::AtomicU64 {
-        unsafe { &mut (*self.cb).write_position.0 }
+    fn write_pos(&self) -> &std::sync::atomic::AtomicU64 {
+        unsafe { &(*self.cb).write_position.0 }
     }
 
     #[inline]
-    fn read_pos(&mut self) -> &mut std::sync::atomic::AtomicU64 {
-        unsafe { &mut (*self.cb).read_position.0 }
+    fn read_pos(&self) -> &std::sync::atomic::AtomicU64 {
+        unsafe { &(*self.cb).read_position.0 }
     }
 }
 


### PR DESCRIPTION
Previously, this allowed two threads to have a `&mut` to the same thing at the same time, which isn't really Rust's thing.

I'm not sure if it's actually UB, because it was only used in a non-mutable fashion, but since it doesn't have to be mutable, why make it mutable?

I wanted to test this with Miri, but sadly this doesn't work because `libc::memfd_create()` is not supported by Miri.