### PR TITLE
Make is_abandoned non-mut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,8 +345,8 @@ where
     }
 
     /// Returns true, if the Reader counterpart was dropped.
-    pub fn is_abandoned(&mut self) -> bool {
-        std::sync::Arc::get_mut(&mut self.mem).is_some()
+    pub fn is_abandoned(&self) -> bool {
+        std::sync::Arc::strong_count(&self.mem) < 2
     }
 
     /// Write and commit a single element, or return it if the queue was full.
@@ -440,8 +440,8 @@ where
     }
 
     /// Returns true, if the Writer counterpart was dropped.
-    pub fn is_abandoned(&mut self) -> bool {
-        std::sync::Arc::get_mut(&mut self.mem).is_some()
+    pub fn is_abandoned(&self) -> bool {
+        std::sync::Arc::strong_count(&self.mem) < 2
     }
 
     #[inline]


### PR DESCRIPTION
I don't think `is_abandoned()` has to take `&mut self`, nor should it.

That's how I'm doing it in `rtrb`: https://github.com/mgeier/rtrb/blob/7390730529fc474691846480de3c4ea59d4688fb/src/lib.rs#L429-L431