### PR TITLE
Make it compile on unsupported platforms

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -29,4 +29,11 @@ jobs:
           cargo test --release
           cargo doc
 
-
+  build_windows:
+    name: Build on Windows (stub)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cueue"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Benedek Thaler"]
 license = "MIT"


### PR DESCRIPTION
The resulting library is useless on those platforms,
but it still allows a shallow form of IDE development.
